### PR TITLE
Backwards support iOS 14

### DIFF
--- a/Asynchrone/Source/Sequence/DebounceAsyncSequence.swift
+++ b/Asynchrone/Source/Sequence/DebounceAsyncSequence.swift
@@ -141,7 +141,7 @@ fileprivate actor _DebounceAsyncSequence<T: AsyncSequence> {
             {
                 self.scheduledTask?.cancel()
                 
-                let delay = UInt64(self.dueTime - Date.now.timeIntervalSince(lastEmission)) * 1_000_000_000
+                let delay = UInt64(self.dueTime - Date().timeIntervalSince(lastEmission)) * 1_000_000_000
                 try? await Task.sleep(nanoseconds: delay)
                 self.continuation?.finish(with: lastElement)
             } else {
@@ -160,7 +160,7 @@ fileprivate actor _DebounceAsyncSequence<T: AsyncSequence> {
         
         // Restart scheduled task
         self.lastElement = element
-        self.lastEmission = .now
+        self.lastEmission = Date()
         
         self.scheduledTask = Task { [dueTime, element, continuation] in
             try? await Task.sleep(nanoseconds: UInt64(dueTime * 1_000_000_000))

--- a/Asynchrone/Source/Sequence/ThrottleAsyncSequence.swift
+++ b/Asynchrone/Source/Sequence/ThrottleAsyncSequence.swift
@@ -144,7 +144,7 @@ extension ThrottleAsyncSequence {
                 }
                 
                 if let lastTime = self.lastEmission {
-                    let gap = Date.now.timeIntervalSince(lastTime)
+                    let gap = Date().timeIntervalSince(lastTime)
                     if gap < self.interval {
                         let delay = self.interval - gap
                         try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
@@ -174,7 +174,7 @@ extension ThrottleAsyncSequence {
                 return
             }
 
-            let gap = Date.now.timeIntervalSince(lastTime)
+            let gap = Date().timeIntervalSince(lastTime)
             if gap >= self.interval {
                 self.emitNextElement()
             }

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 let package = Package(
     name: "Asynchrone",
     platforms: [
-        .iOS("15.0"),
+        .iOS("14.0"),
         .macOS("12.0")
     ],
     products: [

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Extensions and additions to `AsyncSequence`, `AsyncStream` and `AsyncThrowingStr
 
 ## Requirements
 
-- iOS 15.0+
+- iOS 14.0+
 - macOS 12.0+
 
 ## Installation


### PR DESCRIPTION
Now that Xcode 13.2 has support for swift concurrency on iOS 14.