### PR TITLE
Add assign function to async sequence

### DIFF
--- a/Asynchrone/Source/Extensions/AsyncSequence+Extension.swift
+++ b/Asynchrone/Source/Extensions/AsyncSequence+Extension.swift
@@ -1,4 +1,48 @@
 extension AsyncSequence {
+    
+    /// Assigns each element from an async sequence to a property on an object.
+    ///
+    /// ```swift
+    /// class MyClass {
+    ///     var value: Int = 0 {
+    ///         didSet { print("Set to \(self.value)") }
+    ///     }
+    /// }
+    ///
+    ///
+    /// let sequence = AsyncStream<Int> { continuation in
+    ///     continuation.yield(1)
+    ///     continuation.yield(2)
+    ///     continuation.yield(3)
+    ///     continuation.finish()
+    /// }
+    ///
+    /// let object = MyClass()
+    /// sequence.assign(to: \.value, on: object)
+    ///
+    /// // Prints:
+    /// // Set to 1
+    /// // Set to 2
+    /// // Set to 3
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - keyPath: A key path to indicate the property to be assign.
+    ///   - object: The object that contains the property.
+    /// - Returns: A `Task<Void, Error>`. It is not required to keep reference to the task,
+    /// but it does give the ability to cancel the assign by calling `cancel()`.
+    @discardableResult
+    public func assign<Root>(
+        to keyPath: ReferenceWritableKeyPath<Root, Element>,
+        on object: Root
+    ) rethrows -> Task<Void, Error> {
+        Task {
+            for try await element in self {
+                object[keyPath: keyPath] = element
+            }
+        }
+    }
+    
     /// The first element of the sequence, if there is one.
     public func first() async rethrows -> Element? {
         try await self.first { _ in

--- a/AsynchroneTests/Tests/Extensions/AsyncSequenceTests.swift
+++ b/AsynchroneTests/Tests/Extensions/AsyncSequenceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class AsyncSequenceTests: XCTestCase {
     private var sequence: AsyncStream<Int>!
-    
+     
     // MARK: Setup
     
     override func setUpWithError() throws {
@@ -14,6 +14,18 @@ final class AsyncSequenceTests: XCTestCase {
             continuation.yield(3)
             continuation.finish()
         }
+    }
+    
+    // MARK: Assign
+    
+    private var assignableValue: Int = 0
+    
+    func testAssign() async {
+        self.sequence.assign(to: \.assignableValue, on: self)
+        await XCTAssertEventuallyEqual(
+            { self.assignableValue },
+            { 3 }
+        )
     }
     
     // MARK: First

--- a/README.md
+++ b/README.md
@@ -29,6 +29,32 @@ Documentation can be found [here](https://distracted-austin-575f34.netlify.app).
 
 ### [Extensions](https://distracted-austin-575f34.netlify.app/extensions/asyncsequence)
 
+#### Assign
+
+```swift
+class MyClass {
+    var value: Int = 0 {
+        didSet { print("Set to \(self.value)") }
+    }
+}
+
+
+let sequence = AsyncStream<Int> { continuation in
+    continuation.yield(1)
+    continuation.yield(2)
+    continuation.yield(3)
+    continuation.finish()
+}
+
+let object = MyClass()
+sequence.assign(to: \.value, on: object)
+
+// Prints:
+// Set to 1
+// Set to 2
+// Set to 3
+```
+
 #### First
 
 ```swift


### PR DESCRIPTION
```swift
class MyClass {
    var value: Int = 0 {
        didSet { print("Set to \(self.value)") }
    }
}


let sequence = AsyncStream<Int> { continuation in
    continuation.yield(1)
    continuation.yield(2)
    continuation.yield(3)
    continuation.finish()
}

let object = MyClass()
sequence.assign(to: \.value, on: object)

// Prints:
// Set to 1
// Set to 2
// Set to 3
```