### PR TITLE
Add the ability to chain sequences

### DIFF
--- a/Asynchrone.xcodeproj/project.pbxproj
+++ b/Asynchrone.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		A4109A4A27E66C9B0023469A /* TimerAsyncSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4109A4927E66C9B0023469A /* TimerAsyncSequence.swift */; };
 		A4109A4C27E675880023469A /* TimerAsyncSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4109A4B27E675880023469A /* TimerAsyncSequenceTests.swift */; };
 		A4109A4E27E765540023469A /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4109A4D27E765540023469A /* Date+Extension.swift */; };
+		A4482EDD27FC9FFD0004941D /* ChainAsyncSequenceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4482EDC27FC9FFD0004941D /* ChainAsyncSequenceable.swift */; };
+		A4482EDF27FCAACE0004941D /* ChainAsyncSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4482EDE27FCAACE0004941D /* ChainAsyncSequenceTests.swift */; };
 		A45E0EB927748F5A006B64E1 /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45E0EB827748F5A006B64E1 /* Just.swift */; };
 		A45E0EBB277491F1006B64E1 /* JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45E0EBA277491F1006B64E1 /* JustTests.swift */; };
 		A45E0EBD27749897006B64E1 /* Fail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45E0EBC27749897006B64E1 /* Fail.swift */; };
@@ -81,6 +83,8 @@
 		A4109A4927E66C9B0023469A /* TimerAsyncSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerAsyncSequence.swift; sourceTree = "<group>"; };
 		A4109A4B27E675880023469A /* TimerAsyncSequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerAsyncSequenceTests.swift; sourceTree = "<group>"; };
 		A4109A4D27E765540023469A /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
+		A4482EDC27FC9FFD0004941D /* ChainAsyncSequenceable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainAsyncSequenceable.swift; sourceTree = "<group>"; };
+		A4482EDE27FCAACE0004941D /* ChainAsyncSequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainAsyncSequenceTests.swift; sourceTree = "<group>"; };
 		A45E0EB827748F5A006B64E1 /* Just.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Just.swift; sourceTree = "<group>"; };
 		A45E0EBA277491F1006B64E1 /* JustTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustTests.swift; sourceTree = "<group>"; };
 		A45E0EBC27749897006B64E1 /* Fail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fail.swift; sourceTree = "<group>"; };
@@ -148,6 +152,7 @@
 			children = (
 				A45E0EC82774E8D3006B64E1 /* AnyAsyncSequenceableTests.swift */,
 				A45E0ECC2775E6E2006B64E1 /* AnyThrowingAsyncSequenceableTests.swift */,
+				A4482EDE27FCAACE0004941D /* ChainAsyncSequenceTests.swift */,
 				A4C361D4276CDDB500511525 /* CombineLatestAsyncSequenceTests.swift */,
 				A4C361E92770FA7C00511525 /* CombineLatest3AsyncSequenceTests.swift */,
 				A40B6E4127883FD300CA6502 /* CurrentElementAsyncSequenceTests.swift */,
@@ -280,6 +285,7 @@
 				A45E0EC62774E50A006B64E1 /* AnyAsyncSequenceable.swift */,
 				A45E0ECA2775E301006B64E1 /* AnyThrowingAsyncSequenceable.swift */,
 				A40EE2A627A063FC00663E6C /* AsyncSequenceCompletion.swift */,
+				A4482EDC27FC9FFD0004941D /* ChainAsyncSequenceable.swift */,
 				A4C361D2276BB14300511525 /* CombineLatestAsyncSequence.swift */,
 				A4C361E72770F67E00511525 /* CombineLatest3AsyncSequence.swift */,
 				A40B6E3F2787618800CA6502 /* CurrentElementAsyncSequence.swift */,
@@ -433,6 +439,7 @@
 				A45E0EBD27749897006B64E1 /* Fail.swift in Sources */,
 				6470FF6B2775F8E5009CD087 /* ThrottleAsyncSequence.swift in Sources */,
 				A4C361C7276A603B00511525 /* AsyncStream+Extension.swift in Sources */,
+				A4482EDD27FC9FFD0004941D /* ChainAsyncSequenceable.swift in Sources */,
 				A4C361F12772246C00511525 /* ZipAsyncSequence.swift in Sources */,
 				A4C361E82770F67E00511525 /* CombineLatest3AsyncSequence.swift in Sources */,
 				A40B6E462788885800CA6502 /* PassthroughAsyncSequence.swift in Sources */,
@@ -482,6 +489,7 @@
 				A4C361D5276CDDB500511525 /* CombineLatestAsyncSequenceTests.swift in Sources */,
 				A45E0EBB277491F1006B64E1 /* JustTests.swift in Sources */,
 				A45E0EC227749D18006B64E1 /* Assertion.swift in Sources */,
+				A4482EDF27FCAACE0004941D /* ChainAsyncSequenceTests.swift in Sources */,
 				A45E0EC92774E8D3006B64E1 /* AnyAsyncSequenceableTests.swift in Sources */,
 				644E0F09277A27300006CEB8 /* SharedAsyncSequenceTests.swift in Sources */,
 				A4C361DD276D080F00511525 /* AsyncSequenceTests.swift in Sources */,

--- a/Asynchrone/Source/Sequences/ChainAsyncSequenceable.swift
+++ b/Asynchrone/Source/Sequences/ChainAsyncSequenceable.swift
@@ -1,0 +1,156 @@
+/// An asynchronous sequence that chains two async sequences.
+///
+/// The combined sequence first emits the all the values from the first sequence
+/// and then emits all values from the second.
+///
+/// ```swift
+/// let sequenceA = AsyncStream<Int> { continuation in
+///     continuation.yield(1)
+///     continuation.yield(2)
+///     continuation.yield(3)
+///     continuation.finish()
+/// }
+///
+/// let sequenceB = AsyncStream<Int> { continuation in
+///     continuation.yield(4)
+///     continuation.yield(5)
+///     continuation.yield(6)
+///     continuation.finish()
+/// }
+///
+/// let sequenceC = AsyncStream<Int> { continuation in
+///     continuation.yield(7)
+///     continuation.yield(8)
+///     continuation.yield(9)
+///     continuation.finish()
+/// }
+///
+/// for await value in sequenceA <> sequenceB <> sequenceC {
+///     print(value)
+/// }
+///
+/// // Prints:
+/// // 1
+/// // 2
+/// // 3
+/// // 4
+/// // 5
+/// // 6
+/// // 7
+/// // 8
+/// // 9
+/// ```
+public struct ChainAsyncSequence<P: AsyncSequence, Q: AsyncSequence>: AsyncSequence where P.Element == Q.Element {
+    
+    /// The kind of elements streamed.
+    public typealias Element = P.Element
+    
+    // Private
+    private let p: P
+    private let q: Q
+    
+    private var iteratorP: P.AsyncIterator
+    private var iteratorQ: Q.AsyncIterator
+    
+    // MARK: Initialization
+    
+    /// Creates an async sequence that combines the two async sequence.
+    /// - Parameters:
+    ///   - p: The first async sequence.
+    ///   - q: The second async sequence.
+    public init(
+        _ p: P,
+        _ q: Q
+    ) {
+        self.p = p
+        self.iteratorP = p.makeAsyncIterator()
+        
+        self.q = q
+        self.iteratorQ = q.makeAsyncIterator()
+    }
+    
+    // MARK: AsyncSequence
+    
+    /// Creates an async iterator that emits elements of this async sequence.
+    /// - Returns: An instance that conforms to `AsyncIteratorProtocol`.
+    public func makeAsyncIterator() -> Self {
+        .init(self.p, self.q)
+    }
+}
+
+// MARK: AsyncIteratorProtocol
+
+extension ChainAsyncSequence: AsyncIteratorProtocol {
+    
+    /// Produces the next element in the sequence.
+    /// - Returns: The next element or `nil` if the end of the sequence is reached.
+    public mutating func next() async rethrows -> Element? {
+        if let element = try await self.iteratorP.next() {
+            return element
+        } else {
+            return try await self.iteratorQ.next()
+        }
+    }
+}
+
+
+
+// MARK: Chain
+
+precedencegroup ChainOperatorPrecedence {
+    associativity: left
+}
+infix operator <>: ChainOperatorPrecedence
+
+/// An asynchronous sequence that chains two async sequences.
+///
+/// The combined sequence first emits the all the values from the first sequence
+/// and then emits all values from the second.
+///
+/// ```swift
+/// let sequenceA = AsyncStream<Int> { continuation in
+///     continuation.yield(1)
+///     continuation.yield(2)
+///     continuation.yield(3)
+///     continuation.finish()
+/// }
+///
+/// let sequenceB = AsyncStream<Int> { continuation in
+///     continuation.yield(4)
+///     continuation.yield(5)
+///     continuation.yield(6)
+///     continuation.finish()
+/// }
+///
+/// let sequenceC = AsyncStream<Int> { continuation in
+///     continuation.yield(7)
+///     continuation.yield(8)
+///     continuation.yield(9)
+///     continuation.finish()
+/// }
+///
+/// for await value in sequenceA <> sequenceB <> sequenceC {
+///     print(value)
+/// }
+///
+/// // Prints:
+/// // 1
+/// // 2
+/// // 3
+/// // 4
+/// // 5
+/// // 6
+/// // 7
+/// // 8
+/// // 9
+/// ```
+/// - Parameters:
+///   - lhs: The first async sequence to iterate through.
+///   - rhs: The second async sequence to iterate through.
+/// - Returns: A async sequence chains the two sequences.
+public func <><P, Q>(
+    lhs: P,
+    rhs: Q
+) -> ChainAsyncSequence<P, Q> where P: AsyncSequence, Q: AsyncSequence {
+    .init(lhs, rhs)
+}

--- a/AsynchroneTests/Tests/Sequences/ChainAsyncSequenceTests.swift
+++ b/AsynchroneTests/Tests/Sequences/ChainAsyncSequenceTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Asynchrone
+
+
+final class ChainAsyncSequenceTests: XCTestCase {
+    private var sequenceA: AsyncStream<Int>!
+    private var sequenceB: AsyncStream<Int>!
+    private var sequenceC: AsyncStream<Int>!
+    
+    // MARK: Setup
+    
+    override func setUpWithError() throws {
+        self.sequenceA = .init { continuation in
+            continuation.yield(1)
+            continuation.yield(2)
+            continuation.yield(3)
+            continuation.finish()
+        }
+        
+        self.sequenceB = .init { continuation in
+            continuation.yield(4)
+            continuation.yield(5)
+            continuation.yield(6)
+            continuation.finish()
+        }
+        
+        self.sequenceC = .init { continuation in
+            continuation.yield(7)
+            continuation.yield(8)
+            continuation.yield(9)
+            continuation.finish()
+        }
+    }
+    
+    // MARK: Tests
+    
+    func testChainingTwoSequences() async {
+        let values = await (self.sequenceA <> self.sequenceB).collect()
+        XCTAssertEqual(values, [1, 2, 3, 4, 5, 6])
+    }
+    
+    func testChainingThreeSequences() async {
+        let values = await (
+            self.sequenceA <>
+            self.sequenceB <>
+            self.sequenceC
+        ).collect()
+        
+        XCTAssertEqual(values, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -142,6 +142,46 @@ let stream = Fail<Int, TestError>(error: TestError.a)
     .eraseToAnyThrowingAsyncSequenceable()
 ```
 
+### [ChainAsyncSequenceable](https://distracted-austin-575f34.netlify.app/structs/chainasyncsequenceable)
+
+```swift
+let sequenceA = AsyncStream<Int> { continuation in
+    continuation.yield(1)
+    continuation.yield(2)
+    continuation.yield(3)
+    continuation.finish()
+}
+
+let sequenceB = AsyncStream<Int> { continuation in
+    continuation.yield(4)
+    continuation.yield(5)
+    continuation.yield(6)
+    continuation.finish()
+}
+
+let sequenceC = AsyncStream<Int> { continuation in
+    continuation.yield(7)
+    continuation.yield(8)
+    continuation.yield(9)
+    continuation.finish()
+}
+
+for await value in sequenceA <> sequenceB <> sequenceC {
+    print(value)
+}
+
+// Prints:
+// 1
+// 2
+// 3
+// 4
+// 5
+// 6
+// 7
+// 8
+// 9
+```
+
 ### [CombineLatestAsyncSequence](https://distracted-austin-575f34.netlify.app/structs/combinelatestasyncsequence)
 
 ```swift


### PR DESCRIPTION
```swift
let sequenceA = AsyncStream<Int> { continuation in
    continuation.yield(1)
    continuation.yield(2)
    continuation.yield(3)
    continuation.finish()
}

let sequenceB = AsyncStream<Int> { continuation in
    continuation.yield(4)
    continuation.yield(5)
    continuation.yield(6)
    continuation.finish()
}

let sequenceC = AsyncStream<Int> { continuation in
    continuation.yield(7)
    continuation.yield(8)
    continuation.yield(9)
    continuation.finish()
}

for await value in sequenceA <> sequenceB <> sequenceC {
    print(value)
}

// Prints:
// 1
// 2
// 3
// 4
// 5
// 6
// 7
// 8
// 9
```