### PR TITLE
Check for cancellation

### DIFF
--- a/Asynchrone/Source/Extensions/AsyncSequence+Extension.swift
+++ b/Asynchrone/Source/Extensions/AsyncSequence+Extension.swift
@@ -157,8 +157,10 @@ extension AsyncSequence {
             do {
                 for try await element in self {
                     await receiveValue(element)
+                    try Task.checkCancellation()
                 }
-                
+
+                try Task.checkCancellation()
                 await receiveCompletion(.finished)
             } catch {
                 await receiveCompletion(.failure(error))

--- a/AsynchroneTests/Supporting Files/Assertion.swift
+++ b/AsynchroneTests/Supporting Files/Assertion.swift
@@ -25,7 +25,7 @@ func XCTAssertEventuallyEqual<T: Equatable>(
         case true:
             return
         // False and timed out.
-        case false where Date.now.compare(timeoutDate) == .orderedDescending:
+        case false where Date().compare(timeoutDate) == .orderedDescending:
             let error = XCTAssertEventuallyEqualError(
                 resultA: resultA,
                 resultB: resultB
@@ -69,7 +69,7 @@ func XCTAsyncAssertEventuallyEqual<T: Equatable>(
         case true:
             return
         // False and timed out.
-        case false where Date.now.compare(timeoutDate) == .orderedDescending:
+        case false where Date().compare(timeoutDate) == .orderedDescending:
             let error = XCTAssertEventuallyEqualError(
                 resultA: resultA,
                 resultB: resultB


### PR DESCRIPTION
The receive completion handler was never correctly reporting whether the task had been cancelled. It would always return with `.finished` or an error that was thrown by its sequence.