### PR TITLE
Improve shared sequence management

### DIFF
--- a/AsynchroneTests/Tests/Sequences/SharedAsyncSequenceTests.swift
+++ b/AsynchroneTests/Tests/Sequences/SharedAsyncSequenceTests.swift
@@ -12,7 +12,7 @@ final class SharedAsyncSequenceTests: XCTestCase {
     }
 
     // MARK: Tests
-    
+
     func testSharedStreamShouldNotThrowExceptionAndReceiveAllValues() async {
         let taskCompleteExpectation = self.expectation(description: "Task complete")
         Task {


### PR DESCRIPTION
The shared sequence would keep hold of all child sequences, even after they were terminated. This could lead to large memory usage if a single shared sequence was used many many times.