### PR TITLE
Test class had duplicate name

### DIFF
--- a/AsynchroneTests/AsyncRemoveDuplicatesSequenceTests.swift
+++ b/AsynchroneTests/AsyncRemoveDuplicatesSequenceTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Asynchrone
 
 
-final class RemoveDuplicatesAsyncSequenceTests: XCTestCase {
+final class AsyncRemoveDuplicatesAsyncSequenceTests: XCTestCase {
     private var stream: AsyncStream<Int>!
     
     // MARK: Setup


### PR DESCRIPTION
Was just playing around with some tests, and noticed that the test target couldn't build because two classes had the same name. I used the file name as a clue for what to use.

The contents of the tests are extremely similar but not identical, and I think these really are testing different things. Hope this looks ok, but happy to defer to you!