### PR TITLE
Remove unused date extension

### DIFF
--- a/Asynchrone/Source/Extensions/Date+Extension.swift
+++ b/Asynchrone/Source/Extensions/Date+Extension.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-extension Date {
-    @available(iOS 14, tvOS 14, watchOS 7, macOS 11, macCatalyst 14, *)
-    static var now: Date {
-        Date()
-    }
-}


### PR DESCRIPTION
This extension, besides overlapping with Foundation, isn't actually used anywhere in the code as far as I could tell. I believe this was left-over and/or missed in https://github.com/reddavis/Asynchrone/pull/6