### PR TITLE
Basic DocC support

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Asynchrone]

--- a/Sources/Asynchrone/Documentation.docc/Asynchrone.md
+++ b/Sources/Asynchrone/Documentation.docc/Asynchrone.md
@@ -1,0 +1,3 @@
+# ``Asynchrone``
+
+Extensions and additions to AsyncSequence, AsyncStream and AsyncThrowingStream.


### PR DESCRIPTION
You've done an awesome job documenting everything! It's easy, so I thought I'd put together DocC support, along with an `.spi.yml`, so this will be automatically built and hosted by the Swift Package Index.

After they rebuilt the package (~ 24 hours), DocC documentation will show up here: https://swiftpackageindex.com/reddavis/Asynchrone