### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ sequence.sink(
 ### [AnyAsyncSequenceable](https://swiftpackageindex.com/reddavis/asynchrone/main/documentation/asynchrone/anyasyncsequenceable)
 
 ```swift
-let sequence = Just(1)
+let sequence: AnyAsyncSequenceable<String> = Just(1)
     .map(String.init)
     .eraseToAnyAsyncSequenceable()
 ```


### PR DESCRIPTION
The type `AnyAsyncSequenceable` isn't mentioned in the readme, which is needed when declaring a class or struct property. I had to dig through the tests to find it so thought it would be useful for others if it was added to the readme where `eraseToAnyAsyncSequenceable` is used.