### PR TITLE
Fix crash in DebounceAsyncSequence

### DIFF
--- a/Sources/Asynchrone/Sequences/DebounceAsyncSequence.swift
+++ b/Sources/Asynchrone/Sequences/DebounceAsyncSequence.swift
@@ -106,7 +106,7 @@ extension DebounceAsyncSequence {
                 self.resultTask = nil
 
                 let sleep = Task<RaceResult, Never> { [dueTime] in
-                    try? await Task.sleep(nanoseconds: UInt64(Swift.max(dueTime, 0)) * 1_000_000_000)
+                    try? await Task.sleep(nanoseconds: UInt64(Swift.max(dueTime, 0)) * NSEC_PER_SEC)
                     return .sleep
                 }
 

--- a/Sources/Asynchrone/Sequences/DebounceAsyncSequence.swift
+++ b/Sources/Asynchrone/Sequences/DebounceAsyncSequence.swift
@@ -92,8 +92,7 @@ extension DebounceAsyncSequence {
         
         public mutating func next() async rethrows -> Element? {
             var lastResult: Result<Element?, Error>?
-            var lastEmission: Date = .init()
-            
+
             while true {
                 let resultTask = self.resultTask ?? Task<RaceResult, Never> { [base] in
                     var iterator = base
@@ -105,14 +104,12 @@ extension DebounceAsyncSequence {
                     }
                 }
                 self.resultTask = nil
-                
-                lastEmission = Date()
-                let delay = UInt64(self.dueTime - Date().timeIntervalSince(lastEmission)) * 1_000_000_000
-                let sleep = Task<RaceResult, Never> {
-                    try? await Task.sleep(nanoseconds: delay)
+
+                let sleep = Task<RaceResult, Never> { [dueTime] in
+                    try? await Task.sleep(nanoseconds: UInt64(Swift.max(dueTime, 0)) * 1_000_000_000)
                     return .sleep
                 }
-                
+
                 let tasks = [resultTask, sleep]
                 let firstTask = await { () async -> Task<RaceResult, Never> in
                     let raceCoordinator = TaskRaceCoodinator<RaceResult, Never>()
@@ -140,7 +137,6 @@ extension DebounceAsyncSequence {
                 switch await firstTask.value {
                 case .winner(let result, let iterator):
                     lastResult = result
-                    lastEmission = Date()
                     self.base = iterator
                     
                     switch result {


### PR DESCRIPTION
The expression `UInt64(self.dueTime - Date().timeIntervalSince(lastEmission))` crashes if `self.dueTime - Date().timeIntervalSince(lastEmission)` is less than `UInt64.min`.

Since `Date().timeIntervalSince(lastEmission)` seems like it normally evaluates to something near 0, the suspicion is that the crash must occur when the process is suspended in between `lastEmission = Date()` and `Date().timeIntervalSince(lastEmission)`.

This commit removes `lastEmission` entirely and ensures that the value passed to `UInt64.min` is non-negative.

Fixes #60